### PR TITLE
The SetFilled method has a default implementation now

### DIFF
--- a/GiGraph.Dot.Entities/Attributes/Collections/DotClusterAttributes.cs
+++ b/GiGraph.Dot.Entities/Attributes/Collections/DotClusterAttributes.cs
@@ -1,14 +1,6 @@
-using GiGraph.Dot.Entities.Attributes.Enums;
-using GiGraph.Dot.Entities.Types.Colors;
-
 namespace GiGraph.Dot.Entities.Attributes.Collections
 {
     public class DotClusterAttributes : DotEntityAttributes, IDotClusterAttributes
     {
-        public override void SetFilled(DotColorDefinition value)
-        {
-            Style = Style.GetValueOrDefault(DotStyle.Filled) | DotStyle.Filled;
-            FillColor = value;
-        }
     }
 }

--- a/GiGraph.Dot.Entities/Attributes/Collections/DotEntityAttributes.Helpers.cs
+++ b/GiGraph.Dot.Entities/Attributes/Collections/DotEntityAttributes.Helpers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using GiGraph.Dot.Entities.Attributes.Enums;
 using GiGraph.Dot.Entities.Types.Colors;
 
 namespace GiGraph.Dot.Entities.Attributes.Collections
@@ -8,6 +9,10 @@ namespace GiGraph.Dot.Entities.Attributes.Collections
         public virtual void SetFilled(Color color) => SetFilled((DotColorDefinition) color);
         public virtual void SetFilled(DotColorList colorList) => SetFilled((DotColorDefinition) colorList);
 
-        public abstract void SetFilled(DotColorDefinition value);
+        public virtual void SetFilled(DotColorDefinition value)
+        {
+            Style = Style.GetValueOrDefault(DotStyle.Filled) | DotStyle.Filled;
+            FillColor = value;
+        }
     }
 }

--- a/GiGraph.Dot.Entities/Attributes/Collections/DotGraphAttributes.cs
+++ b/GiGraph.Dot.Entities/Attributes/Collections/DotGraphAttributes.cs
@@ -1,6 +1,5 @@
 using System;
 using GiGraph.Dot.Entities.Attributes.Enums;
-using GiGraph.Dot.Entities.Types.Colors;
 
 namespace GiGraph.Dot.Entities.Attributes.Collections
 {
@@ -55,7 +54,5 @@ namespace GiGraph.Dot.Entities.Attributes.Collections
                 ? throw new ArgumentOutOfRangeException(nameof(FontSize), v.Value, "Node spacing must be greater than or equal to 0.")
                 : new DotDoubleAttribute("nodesep", v.Value));
         }
-
-        public override void SetFilled(DotColorDefinition value) => BackgroundColor = value;
     }
 }

--- a/GiGraph.Dot.Entities/Attributes/Collections/DotNodeAttributes.cs
+++ b/GiGraph.Dot.Entities/Attributes/Collections/DotNodeAttributes.cs
@@ -1,6 +1,5 @@
 using System;
 using GiGraph.Dot.Entities.Attributes.Enums;
-using GiGraph.Dot.Entities.Types.Colors;
 
 namespace GiGraph.Dot.Entities.Attributes.Collections
 {
@@ -64,12 +63,6 @@ namespace GiGraph.Dot.Entities.Attributes.Collections
         {
             get => TryGetValueAs<DotNodeSizing>("fixedsize", out var result) ? result : (DotNodeSizing?) null;
             set => AddOrRemove("fixedsize", value, v => new DotNodeFixedSizeAttribute("fixedsize", v.Value));
-        }
-
-        public override void SetFilled(DotColorDefinition value)
-        {
-            Style = Style.GetValueOrDefault(DotStyle.Filled) | DotStyle.Filled;
-            FillColor = value;
         }
     }
 }


### PR DESCRIPTION
It also has a similar effect on the root graph as on other element types (it used to set bgcolor, not fill color).