### PR TITLE
Add implicit support for the cluster attribute on subgraphs and clusters

### DIFF
--- a/src/GiGraph.Dot.Entities.Tests/Attributes/__snapshots__/attribute_property_key_map.snap
+++ b/src/GiGraph.Dot.Entities.Tests/Attributes/__snapshots__/attribute_property_key_map.snap
@@ -21,6 +21,9 @@
   "class": [
     "SvgStyleSheet.Class: String [Graph, Cluster, Node, Edge]"
   ],
+  "cluster": [
+    "IsCluster: Boolean? [Subgraph, Cluster]"
+  ],
   "clusterrank": [
     "Clusters.VisualizationMode: DotClusterVisualizationMode? [Graph]"
   ],

--- a/src/GiGraph.Dot.Entities/Clusters/Attributes/DotClusterRootAttributes.cs
+++ b/src/GiGraph.Dot.Entities/Clusters/Attributes/DotClusterRootAttributes.cs
@@ -48,6 +48,13 @@ public class DotClusterRootAttributes : DotClusterNodeRootCommonAttributes<IDotC
         LabelAlignment = labelAlignmentAttributes;
     }
 
+    [DotAttributeKey(DotAttributeKeys.Cluster)]
+    bool? IDotClusterAttributes.IsCluster
+    {
+        get => GetValueAsBool(MethodBase.GetCurrentMethod());
+        set => SetOrRemove(MethodBase.GetCurrentMethod(), value);
+    }
+
     public DotFontAttributes Font { get; }
     public DotClusterStyleAttributeOptions Style { get; }
     public DotLabelAlignmentAttributes LabelAlignment { get; }

--- a/src/GiGraph.Dot.Entities/Clusters/Attributes/IDotClusterAttributes.cs
+++ b/src/GiGraph.Dot.Entities/Clusters/Attributes/IDotClusterAttributes.cs
@@ -3,6 +3,7 @@ using GiGraph.Dot.Entities.Graphs.Attributes;
 using GiGraph.Dot.Entities.Html.Builder;
 using GiGraph.Dot.Entities.Html.Font.Styles;
 using GiGraph.Dot.Entities.Labels;
+using GiGraph.Dot.Entities.Subgraphs;
 using GiGraph.Dot.Types.Clusters;
 using GiGraph.Dot.Types.Colors;
 using GiGraph.Dot.Types.EscapeString;
@@ -137,4 +138,17 @@ public interface IDotClusterAttributes : IDotGraphClusterCommonAttributes
     ///     Gets or sets the rank constraints on the nodes in the cluster (dot only).
     /// </summary>
     DotRank? NodeRank { get; set; }
+
+    /// <summary>
+    ///     <para>
+    ///         Determines whether the subgraph is a cluster (default false). Subgraph clusters are rendered differently, e.g. dot
+    ///         renders a box around subgraph clusters, but doesn't draw a box around non-subgraph clusters.
+    ///     </para>
+    ///     <para>
+    ///         Since this library makes a strong distinction between subgraphs and clusters (in terms of what purpose they are used for
+    ///         and what attributes are settable on each of them), you should use a <see cref="DotSubgraph" /> rather than a cluster with
+    ///         <see cref="IsCluster" /> set to <see langword="false" />.
+    ///     </para>
+    /// </summary>
+    bool? IsCluster { get; set; }
 }

--- a/src/GiGraph.Dot.Entities/Clusters/DotClusterSection.Attributes.cs
+++ b/src/GiGraph.Dot.Entities/Clusters/DotClusterSection.Attributes.cs
@@ -134,4 +134,11 @@ public partial class DotClusterSection : IDotClusterRootAttributes
         get => Attributes.Implementation.NodeRank;
         set => Attributes.Implementation.NodeRank = value;
     }
+
+    /// <inheritdoc cref="IDotClusterAttributes.IsCluster" />
+    public virtual bool? IsCluster
+    {
+        get => ((IDotClusterAttributes) Attributes.Implementation).IsCluster;
+        set => ((IDotClusterAttributes) Attributes.Implementation).IsCluster = value;
+    }
 }

--- a/src/GiGraph.Dot.Entities/Subgraphs/Attributes/DotSubgraphRootAttributes.cs
+++ b/src/GiGraph.Dot.Entities/Subgraphs/Attributes/DotSubgraphRootAttributes.cs
@@ -28,4 +28,11 @@ public class DotSubgraphRootAttributes : DotEntityAttributesWithMetadata<IDotSub
         get => GetValueAs<DotRank>(MethodBase.GetCurrentMethod(), out var result) ? result : null;
         set => SetOrRemove(MethodBase.GetCurrentMethod(), value.HasValue, () => value!.Value);
     }
+
+    [DotAttributeKey(DotAttributeKeys.Cluster)]
+    bool? IDotSubgraphAttributes.IsCluster
+    {
+        get => GetValueAsBool(MethodBase.GetCurrentMethod());
+        set => SetOrRemove(MethodBase.GetCurrentMethod(), value);
+    }
 }

--- a/src/GiGraph.Dot.Entities/Subgraphs/Attributes/IDotSubgraphAttributes.cs
+++ b/src/GiGraph.Dot.Entities/Subgraphs/Attributes/IDotSubgraphAttributes.cs
@@ -1,4 +1,5 @@
-﻿using GiGraph.Dot.Types.Ranks;
+﻿using GiGraph.Dot.Entities.Clusters;
+using GiGraph.Dot.Types.Ranks;
 
 namespace GiGraph.Dot.Entities.Subgraphs.Attributes;
 
@@ -8,4 +9,17 @@ public interface IDotSubgraphAttributes
     ///     Gets or sets the rank constraints on the nodes in the subgraph (dot only).
     /// </summary>
     DotRank? NodeRank { get; set; }
+
+    /// <summary>
+    ///     <para>
+    ///         Determines whether the subgraph is a cluster (default false). Subgraph clusters are rendered differently, e.g. dot
+    ///         renders a box around subgraph clusters, but doesn't draw a box around non-subgraph clusters.
+    ///     </para>
+    ///     <para>
+    ///         Since this library makes a strong distinction between subgraphs and clusters (in terms of what purpose they are used for
+    ///         and what attributes are settable on each of them), you should use a <see cref="DotCluster" /> rather than a subgraph with
+    ///         <see cref="IsCluster" /> set to <see langword="true" />.
+    ///     </para>
+    /// </summary>
+    bool? IsCluster { get; set; }
 }

--- a/src/GiGraph.Dot.Entities/Subgraphs/DotSubgraphSection.Attributes.cs
+++ b/src/GiGraph.Dot.Entities/Subgraphs/DotSubgraphSection.Attributes.cs
@@ -11,4 +11,11 @@ public partial class DotSubgraphSection : IDotSubgraphRootAttributes
         get => Attributes.Implementation.NodeRank;
         set => Attributes.Implementation.NodeRank = value;
     }
+
+    /// <inheritdoc cref="IDotSubgraphAttributes.IsCluster" />
+    public virtual bool? IsCluster
+    {
+        get => ((IDotSubgraphAttributes) Attributes.Implementation).IsCluster;
+        set => ((IDotSubgraphAttributes) Attributes.Implementation).IsCluster = value;
+    }
 }

--- a/src/GiGraph.Dot.Output/Metadata/DotAttributeKeys.cs
+++ b/src/GiGraph.Dot.Output/Metadata/DotAttributeKeys.cs
@@ -46,7 +46,7 @@ public static class DotAttributeKeys
     [DotAttributeMetadata(DotCompatibleElements.Graph, DotCompatibleLayoutEngines.Dot)]
     public const string ClusterRank = "clusterrank";
 
-    [DotAttributeMetadata(DotCompatibleElements.Subgraph | DotCompatibleElements.Cluster, isImplemented: false)]
+    [DotAttributeMetadata(DotCompatibleElements.Subgraph | DotCompatibleElements.Cluster)]
     public const string Cluster = "cluster";
 
     // based on the documentation, the attribute is not supported by the root graph, but when set, it is actually inherited by clusters


### PR DESCRIPTION
The properties are 'hidden' because of the distinction the library makes between subgraphs and clusters, so the attribute should not be used normally